### PR TITLE
Change GitBlame to GitLense to match readme

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 	"extensionDependencies": [
 		"donjayamanne.githistory",
 		"alefragnani.project-manager",
-		"waderyan.gitblame",
+                "eamodio.gitlens",
 		"codezombiech.gitignore",
 		"ziyasal.vscode-open-in-github"
 	]


### PR DESCRIPTION
In a previous PR, it seems that the wrong extension was removed.
GitLens is a superset of git-blame so it makes sense to use that extension.

@DonJayamanne What do you think?