### PR TITLE
Fixes Spelling for GitLens Elevator Pitch

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This extension pack packages some of the most popular (and some of my favorite) 
 
 * [Git History (git log)](https://marketplace.visualstudio.com/items?itemName=donjayamanne.githistory) - View git log, file or line history.
 * [Project Manager](https://marketplace.visualstudio.com/items?itemName=alefragnani.project-manager) - Easily switch between projects.
-* [GitLens](https://marketplace.visualstudio.com/items?itemName=eamodio.gitlens) - GitLens **supercharges** the built-in Visual Studio Code Git capabilities. It helps you to **visualize code authorship** at a glance via inline Git blame annotations and code lens, **seamlessly navigate and explore** the history of a file or branch, **gain valuable insights** via powerful comparision commands, and so much more.
+* [GitLens](https://marketplace.visualstudio.com/items?itemName=eamodio.gitlens) - GitLens **supercharges** the built-in Visual Studio Code Git capabilities. It helps you to **visualize code authorship** at a glance via inline Git blame annotations and code lens, **seamlessly navigate and explore** the history of a file or branch, **gain valuable insights** via powerful comparison commands, and so much more.
 * [gitignore](https://marketplace.visualstudio.com/items?itemName=codezombiech.gitignore) - Language support for .gitignore files. Lets you pull .gitignore files from the https://github.com/github/gitignore repository.  
 * [Open in GitHub / Bitbucket / VisualStudio.com](https://marketplace.visualstudio.com/items?itemName=ziyasal.vscode-open-in-github) - Jump to a source code line in Github / Bitbucket / VisualStudio.com.  
   


### PR DESCRIPTION
Changed the incorrectly spelled "comparision" to "comparison" in the GitLens description. Hi there, I am an employee at GitKraken where GitLens creator Eric Amodio works. This should fix a minor spelling error in the GitLens description. Hope this is helpful, cheers! 